### PR TITLE
Fix backend import path and add frontend webpack deps

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,11 +17,13 @@ pip install -r requirements.txt
 3. Initialize the database tables:
 
 ```bash
-python -c "from app import db, app; app.app_context().push(); db.create_all()"
+# Run this from the project root so the `backend` package can be imported
+python -c "from backend.app import db, app; app.app_context().push(); db.create_all()"
 ```
 
 4. Run the development server:
 
 ```bash
-flask --app app run
+# Run this from the project root so Flask can import the backend package
+flask --app backend.app run
 ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,8 @@
 import os
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from models import db, User, Post, Comment, Subreddit
+# Use an absolute import so running the app from the project root works
+from backend.models import db, User, Post, Comment, Subreddit
 from dotenv import load_dotenv
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,11 @@ This directory contains a minimal React setup using webpack.
 npm install
 ```
 
+This will install React along with the webpack tooling defined in
+`package.json` (webpack, webpack-dev-server, Babel, etc.). The `npm start`
+command relies on these local packages, so running `npm install` is required
+before starting the server.
+
 2. Start the development server:
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,16 @@
     "react-dom": "^18.2.0",
     "axios": "^1.4.0"
   },
+  "devDependencies": {
+    "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5",
+    "babel-loader": "^9.1.3",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
   "scripts": {
     "start": "webpack serve --mode development",
     "build": "webpack --mode production"


### PR DESCRIPTION
## Summary
- fix `backend.app` imports so the server can be started from the repo root
- document running the backend with the full module path
- add webpack/babel dev dependencies for the frontend
- clarify `npm install` step in the frontend README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e02edb5d883319656182958850aa0