### PR TITLE
Make frontend API URL configurable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:5000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,3 +22,14 @@ npm start
 ```
 
 The application will be available at `http://localhost:8080` by default.
+
+### Configuring the API URL
+
+The frontend reads the backend's base URL from the environment variable
+`REACT_APP_API_URL`. Copy `.env.example` to `.env` and edit it if your backend
+is not running on `http://localhost:5000`:
+
+```bash
+cp .env.example .env
+# then edit .env to point to your backend
+```

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,11 +4,15 @@ import axios from 'axios';
 function App() {
   const [posts, setPosts] = useState([]);
 
+  // Base URL for the backend API can be configured via REACT_APP_API_URL.
+  // Default to localhost if no environment variable is provided.
+  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+
   useEffect(() => {
-    axios.get('http://localhost:5000/posts').then(res => {
+    axios.get(`${apiUrl}/posts`).then(res => {
       setPosts(res.data);
     });
-  }, []);
+  }, [apiUrl]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- allow configuring API base URL using `REACT_APP_API_URL`
- document backend URL configuration and add example env file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e049583bc8331bf5cc9a2b8ee422f