### PR TITLE
Fix process undefined error

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: './src/index.js',
@@ -17,7 +18,10 @@ module.exports = {
     ]
   },
   plugins: [
-    new HtmlWebpackPlugin({ template: './public/index.html' })
+    new HtmlWebpackPlugin({ template: './public/index.html' }),
+    new webpack.DefinePlugin({
+      'process.env.REACT_APP_API_URL': JSON.stringify(process.env.REACT_APP_API_URL)
+    })
   ],
   devServer: {
     static: './dist'


### PR DESCRIPTION
## Summary
- define React backend URL in webpack to avoid `process` reference errors

## Testing
- `npm run build` *(fails: webpack not found)*


------
https://chatgpt.com/codex/tasks/task_e_683e07796b5c8331ad83ff8376f3816f